### PR TITLE
Add useNativeDriver to with-video-background example

### DIFF
--- a/with-video-background/App.js
+++ b/with-video-background/App.js
@@ -21,7 +21,8 @@ export default function App() {
             onLoad={() => {
               // https://facebook.github.io/react-native/docs/animated#timing
               Animated.timing(opacity, {
-                toValue: 1
+                toValue: 1,
+                useNativeDriver: true,
               }).start();
             }}
             resizeMode="cover"


### PR DESCRIPTION
Fixes a TypeScript error when using this example with TypeScript, since it expects `useNativeDriver` to be defined.